### PR TITLE
Add Hue observer

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -1,0 +1,6 @@
+use crate::model::Device;
+
+#[derive(Debug)]
+pub(crate) enum Event {
+    DiscoveredDevices(Vec<Device>),
+}

--- a/src/hue/client.rs
+++ b/src/hue/client.rs
@@ -18,7 +18,7 @@ impl HueClient {
         })
     }
 
-    pub async fn fetch_devices(&self) -> Result<DevicesResponse, HueClientError> {
+    pub(in crate::hue) async fn fetch_devices(&self) -> Result<DevicesResponse, HueClientError> {
         let response = self
             .client
             .get(format!("https://{}/clip/v2/resource", self.endpoint))

--- a/src/hue/devices_response.rs
+++ b/src/hue/devices_response.rs
@@ -209,7 +209,49 @@ pub(crate) enum ButtonEvent {
 #[derive(Deserialize, PartialEq, Debug)]
 pub(crate) struct ResourceIdentifierGet {
     rid: String,
-    rtype: String,
+    rtype: ResourceType,
+}
+
+#[derive(Deserialize, PartialEq, Debug)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ResourceType {
+    AuthV1,
+    BehaviorInstance,
+    BehaviorScript,
+    Bridge,
+    BridgeHome,
+    Button,
+    CameraMotion,
+    Contact,
+    Device, // Manually added based on data
+    DevicePower,
+    DeviceSoftwareUpdate, // Manually added
+    Entertainment,
+    EntertainmentConfiguration,
+    Geofence,
+    GeofenceClient,
+    Geolocation,
+    GroupedLight,
+    Homekit,
+    Light,
+    LightLevel,
+    Matter,
+    MatterFabric,
+    Motion,
+    PublicImage,
+    RelativeRotary,
+    Room,
+    Scene,
+    SmartScene,
+    Tamper,
+    #[serde(rename = "taurus_7455")]
+    Taurus, // Manually added
+    Temperature,
+    ZgpConnectivity,
+    ZigbeeBridgeConnectivity,
+    ZigbeeConnectivity,
+    ZigbeeDeviceDiscovery,
+    Zone,
 }
 
 #[derive(Deserialize, PartialEq, Debug)]
@@ -304,19 +346,19 @@ mod tests {
                 vec![
                     ResourceIdentifierGet {
                         rid: "7a0ece11-0e2d-4bbf-b290-1d575b541533".to_string(),
-                        rtype: "zigbee_connectivity".to_string()
+                        rtype: ResourceType::ZigbeeConnectivity
                     },
                     ResourceIdentifierGet {
                         rid: "4e5ad66f-633e-4300-84cd-634129fdb451".to_string(),
-                        rtype: "light".to_string()
+                        rtype: ResourceType::Light
                     },
                     ResourceIdentifierGet {
                         rid: "5d25baca-11e6-4635-91e2-e4db0b538cc9".to_string(),
-                        rtype: "taurus_7455".to_string()
+                        rtype: ResourceType::Taurus
                     },
                     ResourceIdentifierGet {
                         rid: "64ac92d6-41b3-4f81-bd6d-315f01dc59c3".to_string(),
-                        rtype: "device_software_update".to_string()
+                        rtype: ResourceType::DeviceSoftwareUpdate
                     }
                 ],
                 device.services
@@ -338,7 +380,7 @@ mod tests {
             assert_eq!(
                 ResourceIdentifierGet {
                     rid: "90bdce60-3704-470e-be4c-8264f2bc8151".to_string(),
-                    rtype: "device".to_string()
+                    rtype: ResourceType::Device
                 },
                 light.owner
             );
@@ -399,7 +441,7 @@ mod tests {
             assert_eq!(
                 ResourceIdentifierGet {
                     rid: "e84075f8-023f-43e7-80ea-c0246fdf2835".to_string(),
-                    rtype: "device".to_string()
+                    rtype: ResourceType::Device
                 },
                 button.owner
             );

--- a/src/hue/mod.rs
+++ b/src/hue/mod.rs
@@ -1,3 +1,8 @@
-pub mod client;
+mod client;
 mod devices_response;
 mod observer;
+
+pub use client::HueClient;
+pub use client::HueClientError;
+pub use observer::HueObserver;
+pub use observer::HueObserverError;

--- a/src/hue/mod.rs
+++ b/src/hue/mod.rs
@@ -1,2 +1,3 @@
 pub mod client;
 mod devices_response;
+mod observer;

--- a/src/hue/observer.rs
+++ b/src/hue/observer.rs
@@ -9,7 +9,7 @@ use crate::hue::devices_response::{
 };
 use crate::model::{BooleanProperty, Device, DeviceType, Property, PropertyType};
 
-struct HueObserver {
+pub struct HueObserver {
     client: HueClient,
 }
 

--- a/src/hue/observer.rs
+++ b/src/hue/observer.rs
@@ -1,0 +1,174 @@
+use std::collections::HashMap;
+
+use thiserror::Error;
+
+use crate::event::Event;
+use crate::hue::client::{HueClient, HueClientError};
+use crate::hue::devices_response::{
+    DeviceGet, HueError, LightGet, Resource, ResourceIdentifierGet, ResourceType,
+};
+use crate::model::{BooleanProperty, Device, DeviceType, Property, PropertyType};
+
+struct HueObserver {
+    client: HueClient,
+}
+
+impl HueObserver {
+    pub fn new(client: HueClient) -> HueObserver {
+        HueObserver { client }
+    }
+
+    pub async fn observe(&self) -> Result<Event, HueObserverError> {
+        let response = self.client.fetch_devices().await?;
+        if response.errors().len() > 0 {
+            return Err(HueObserverError::FetchDevicesResponse(
+                response.take_errors(),
+            ));
+        }
+
+        let resource_map = response.devices_map();
+        let devices = response
+            .devices()
+            .iter()
+            .try_fold(vec![], |devices: Vec<Device>, device| {
+                fold_device(devices, device, &resource_map)
+            })?;
+
+        Ok(Event::DiscoveredDevices(devices))
+    }
+}
+
+fn fold_device(
+    mut devices: Vec<Device>,
+    device: &&DeviceGet,
+    resource_map: &HashMap<String, &Resource>,
+) -> Result<Vec<Device>, HueObserverError> {
+    let properties: HashMap<String, Property> = device
+        .services()
+        .iter()
+        .try_fold(HashMap::new(), |properties, service| {
+            fold_services(properties, service, resource_map)
+        })?;
+
+    if properties.len() > 0 {
+        let device = map_device(device, properties, None);
+        devices.push(device);
+    }
+
+    Ok(devices)
+}
+
+fn fold_services(
+    mut properties: HashMap<String, Property>,
+    service: &&ResourceIdentifierGet,
+    resource_map: &HashMap<String, &Resource>,
+) -> Result<HashMap<String, Property>, HueObserverError> {
+    match service.rtype() {
+        ResourceType::Light => {
+            if let Resource::Light(light) = resource_map[service.rid()] {
+                properties.extend(&mut map_lights(light).drain());
+            } else {
+                return Err(HueObserverError::InvalidData);
+            }
+        }
+        _ => {}
+    }
+
+    Ok(properties)
+}
+
+fn map_device(
+    device: &DeviceGet,
+    properties: HashMap<String, Property>,
+    external_id: Option<String>,
+) -> Device {
+    Device::new(
+        device.id().to_string(),
+        DeviceType::Light,
+        device.product_data().manufacturer_name().to_string(),
+        device.product_data().model_id().to_string(),
+        device.product_data().product_name().to_string(),
+        device.metadata().name().to_string(),
+        properties,
+        external_id,
+    )
+}
+
+fn map_lights(light: &LightGet) -> HashMap<String, Property> {
+    let mut properties: HashMap<String, Property> = HashMap::new();
+    let on_property = Property::Boolean(BooleanProperty::new(
+        "on".to_string(),
+        false,
+        PropertyType::On,
+        None,
+        light.on(),
+    ));
+    properties.insert("on".to_string(), on_property);
+    properties
+}
+
+#[derive(Error, Debug)]
+pub enum HueObserverError {
+    #[error(transparent)]
+    ClientError(#[from] HueClientError),
+    #[error("fetch devices response contains errors")]
+    FetchDevicesResponse(Vec<HueError>),
+    #[error("invalid data received from the bridge, a service is not pointing to a valid device")]
+    InvalidData,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::error::Error;
+    use std::fs;
+
+    use serde_json::from_str;
+
+    use crate::hue::devices_response::{DevicesResponse, Resource};
+    use crate::hue::observer::fold_device;
+    use crate::model::{Property, PropertyType};
+
+    #[test]
+    fn folds_a_device_with_one_service() -> Result<(), Box<dyn Error>> {
+        let response = fs::read_to_string("tests/resources/devices_response_light.json")?;
+        let response = from_str::<DevicesResponse>(&response)?;
+
+        if let Resource::Device(device) = response.data()[0] {
+            let devices = fold_device(vec![], &device, &response.devices_map())?;
+            assert_eq!(1, devices.len());
+            assert_eq!(1, devices[0].properties().len());
+
+            if let Property::Boolean(on_property) = &devices[0].properties()["on"] {
+                assert_eq!("on", on_property.name());
+                assert_eq!(false, on_property.readonly());
+                assert_eq!(PropertyType::On, *on_property.property_type());
+                assert_eq!(None, on_property.external_id());
+                assert_eq!(true, on_property.value());
+            } else {
+                assert!(false, r#"property["on"] is not a Resource::Device"#);
+            }
+            let property = &devices[0].properties()["on"];
+            assert!(matches!(property, Property::Boolean(_)))
+        } else {
+            assert!(false, "data[0] is not a Resource::Device");
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn folds_a_device_with_no_used_services() -> Result<(), Box<dyn Error>> {
+        let response = fs::read_to_string("tests/resources/devices_with_no_services.json")?;
+        let response = from_str::<DevicesResponse>(&response)?;
+
+        if let Resource::Device(device) = response.data()[0] {
+            let devices = fold_device(vec![], &device, &response.devices_map())?;
+            assert_eq!(0, devices.len());
+        } else {
+            assert!(false, "data[0] is not a Resource::Device");
+        }
+
+        Ok(())
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ use std::error::Error;
 
 use crate::hue::client::HueClient;
 
+mod event;
 mod hue;
 mod model;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use std::error::Error;
 
-use crate::hue::client::HueClient;
+use crate::hue::{HueClient, HueObserver};
 
 mod event;
 mod hue;
@@ -10,7 +10,8 @@ mod model;
 async fn main() -> Result<(), Box<dyn Error>> {
     println!("Retrieving devices from Philips Hue...");
     let client = HueClient::new()?;
-    let response = client.fetch_devices().await?;
+    let observer = HueObserver::new(client);
+    let response = observer.observe().await?;
     eprintln!("response = {:#?}", response);
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ use std::error::Error;
 use crate::hue::client::HueClient;
 
 mod hue;
+mod model;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {

--- a/src/model/boolean_property.rs
+++ b/src/model/boolean_property.rs
@@ -1,0 +1,42 @@
+use crate::model::{Common, PropertyType};
+
+#[derive(Debug)]
+pub struct BooleanProperty {
+    common: Common,
+    value: bool,
+}
+
+impl BooleanProperty {
+    pub fn new(
+        name: String,
+        readonly: bool,
+        property_type: PropertyType,
+        external_id: Option<String>,
+        value: bool,
+    ) -> Self {
+        BooleanProperty {
+            common: Common::new(name, readonly, property_type, external_id),
+            value,
+        }
+    }
+
+    pub fn name(&self) -> &String {
+        &self.common.name()
+    }
+
+    pub fn readonly(&self) -> bool {
+        self.common.readonly()
+    }
+
+    pub fn property_type(&self) -> &PropertyType {
+        &self.common.property_type()
+    }
+
+    pub fn external_id(&self) -> Option<&String> {
+        self.common.external_id()
+    }
+
+    pub fn value(&self) -> bool {
+        self.value
+    }
+}

--- a/src/model/device.rs
+++ b/src/model/device.rs
@@ -1,0 +1,134 @@
+use crate::model::{BooleanProperty, NumberProperty};
+use std::collections::HashMap;
+
+#[derive(Debug)]
+pub struct Device {
+    id: String,
+    device_type: DeviceType,
+    manufacturer: String,
+    model_id: String,
+    product_name: String,
+    name: String,
+    properties: HashMap<String, Property>,
+    external_id: Option<String>,
+}
+
+impl Device {
+    pub fn new(
+        id: String,
+        device_type: DeviceType,
+        manufacturer: String,
+        model_id: String,
+        product_name: String,
+        name: String,
+        properties: HashMap<String, Property>,
+        external_id: Option<String>,
+    ) -> Device {
+        Device {
+            id,
+            device_type,
+            manufacturer,
+            model_id,
+            product_name,
+            name,
+            properties,
+            external_id,
+        }
+    }
+
+    pub fn id(&self) -> &String {
+        &self.id
+    }
+
+    pub fn device_type(&self) -> &DeviceType {
+        &self.device_type
+    }
+
+    pub fn manufacturer(&self) -> &String {
+        &self.manufacturer
+    }
+
+    pub fn model_id(&self) -> &String {
+        &self.model_id
+    }
+
+    pub fn product_name(&self) -> &String {
+        &self.product_name
+    }
+
+    pub fn name(&self) -> &String {
+        &self.name
+    }
+
+    pub fn properties(&self) -> &HashMap<String, Property> {
+        &self.properties
+    }
+
+    pub fn external_id(&self) -> Option<&String> {
+        self.external_id.as_ref()
+    }
+}
+
+#[derive(Debug)]
+pub enum DeviceType {
+    Light,
+}
+
+#[derive(Debug)]
+pub enum Property {
+    Boolean(BooleanProperty),
+    Number(NumberProperty),
+}
+
+#[derive(Debug)]
+pub(in crate::model) struct Common {
+    name: String,
+    readonly: bool,
+    property_type: PropertyType,
+    external_id: Option<String>,
+}
+
+impl Common {
+    pub fn new(
+        name: String,
+        readonly: bool,
+        property_type: PropertyType,
+        external_id: Option<String>,
+    ) -> Self {
+        Common {
+            name,
+            readonly,
+            property_type,
+            external_id,
+        }
+    }
+
+    pub fn name(&self) -> &String {
+        &self.name
+    }
+
+    pub fn readonly(&self) -> bool {
+        self.readonly
+    }
+
+    pub fn property_type(&self) -> &PropertyType {
+        &self.property_type
+    }
+
+    pub fn external_id(&self) -> Option<&String> {
+        self.external_id.as_ref()
+    }
+}
+
+#[derive(Debug)]
+pub enum PropertyType {
+    BatteryLevel,
+    Brightness,
+    Button,
+    Color,
+    ColorTemperature,
+    LightLevel,
+    Motion,
+    On,
+    Temperature,
+}

--- a/src/model/device.rs
+++ b/src/model/device.rs
@@ -120,7 +120,7 @@ impl Common {
     }
 }
 
-#[derive(Debug)]
+#[derive(PartialEq, Debug)]
 pub enum PropertyType {
     BatteryLevel,
     Brightness,

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -1,0 +1,7 @@
+mod boolean_property;
+mod device;
+mod number_property;
+
+pub use boolean_property::BooleanProperty;
+pub use device::*;
+pub use number_property::{NumberProperty, Unit};

--- a/src/model/number_property.rs
+++ b/src/model/number_property.rs
@@ -1,0 +1,71 @@
+use crate::model::{Common, PropertyType};
+
+#[derive(Debug)]
+pub struct NumberProperty {
+    common: Common,
+    unit: Unit,
+    value: Option<usize>,
+    minimum: Option<usize>,
+    maximum: Option<usize>,
+}
+
+impl NumberProperty {
+    pub fn new(
+        name: String,
+        readonly: bool,
+        property_type: PropertyType,
+        external_id: Option<String>,
+        unit: Unit,
+        value: Option<usize>,
+        minimum: Option<usize>,
+        maximum: Option<usize>,
+    ) -> Self {
+        NumberProperty {
+            common: Common::new(name, readonly, property_type, external_id),
+            unit,
+            value,
+            minimum,
+            maximum,
+        }
+    }
+
+    pub fn name(&self) -> &String {
+        &self.common.name()
+    }
+
+    pub fn readonly(&self) -> bool {
+        self.common.readonly()
+    }
+
+    pub fn property_type(&self) -> &PropertyType {
+        &self.common.property_type()
+    }
+
+    pub fn external_id(&self) -> Option<&String> {
+        self.common.external_id()
+    }
+
+    pub fn unit(&self) -> &Unit {
+        &self.unit
+    }
+
+    pub fn value(&self) -> Option<usize> {
+        self.value
+    }
+
+    pub fn minimum(&self) -> Option<usize> {
+        self.minimum
+    }
+
+    pub fn maximum(&self) -> Option<usize> {
+        self.maximum
+    }
+}
+
+#[derive(Debug)]
+pub enum Unit {
+    Percentage,
+    Lumen,
+    Celcius,
+    Kelvin,
+}

--- a/tests/resources/devices_with_no_services.json
+++ b/tests/resources/devices_with_no_services.json
@@ -1,0 +1,25 @@
+{
+  "errors": [],
+  "data": [
+    {
+      "id": "90bdce60-3704-470e-be4c-8264f2bc8151",
+      "id_v1": "/lights/25",
+      "product_data": {
+        "model_id": "LWA021",
+        "manufacturer_name": "Signify Netherlands B.V.",
+        "product_name": "Hue filament bulb",
+        "product_archetype": "vintage_bulb",
+        "certified": true,
+        "software_version": "1.104.2",
+        "hardware_platform_type": "100b-114"
+      },
+      "metadata": {
+        "name": "Light",
+        "archetype": "vintage_bulb"
+      },
+      "identify": {},
+      "services": [],
+      "type": "device"
+    }
+  ]
+}


### PR DESCRIPTION
- The `HueObserver` uses the `HueClient` to retrieve all devices
- Define `Device` and `Property`
- Define two properties: boolean and number
- Define `Event`, with a single event: DiscoveredDevices
- Map the devices response to a list of devices, returned as an event

